### PR TITLE
1. Add a Makefile 2. Fix typos 3. change ways to parse CLI parameters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+CC = gcc
+CFLAGS = -g -Wall -Werror
+
+all: mproxy
+
+mproxy: mproxy.o
+	$(CC) $(CFLAGS) mproxy.o -o mproxy
+
+mproxy.o:
+	$(CC) $(CFLAGS) -c mproxy.c
+
+clean:
+	rm -rf *.o
+	rm mproxy


### PR DESCRIPTION
1. Add a Makefile
2. Fix the typo: "deamon" ==> "daemon"
3. Change the ways to parse command-line-argument, using getopt() to make code more consise and readable, without affecting its functionality.

Signed-off-by: Siyuan Hua jonnyhsy@foxmail.com
