### PR TITLE
Fix a bug:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,11 @@
 *.log
+# VIM temperary file
+*.swp
+*.[ao]
+# cscope's index file: cscope.out, cscope.in.out, cscope.po.out ($ cscope -Rbq)
+*.out
+# ctags's index file: tags  ($ ctags -R)
+tags
+# log of the git commit, it's myself.
+/comment
+/mproxy


### PR DESCRIPTION
Fix a bug:
    1. ./mproxy -l abc -h name:abc .... should return a error.
    2. ./mproxy -l -h -d -E , should return a error.
    3. update a prompt information.
    4. add a function to print error information of command-line argument.
